### PR TITLE
(Bug) Return when lacking menuitems

### DIFF
--- a/context.js
+++ b/context.js
@@ -146,6 +146,12 @@ context = (function() {
 	}
 
 	function _contextHandler(e, id) {
+		var menuItems = getMenuData(id);
+
+		if(!menuItems){
+			return;
+		}
+
 		e.preventDefault();
 		e.stopPropagation();
 
@@ -155,7 +161,6 @@ context = (function() {
 
 		e._contextHandled = true;
 
-		var menuItems = getMenuData(id);
 		currentContextSelector = $(e.target);
 
 		$('.dropdown-context:not(.dropdown-context-sub)').hide();

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "context.js",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "description": "",
   "main": "index.js",
   "license": "Unlicense",


### PR DESCRIPTION
Also move preventDefault and stopPropogation after menu item check. IF there is no menu items, allow the browser to display the normal options.