### PR TITLE
(Task) Destroy context directly from the target

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -29,5 +29,5 @@
     "demo2.html",
     "demo2.js"
   ],
-  "version": "0.3.0"
+  "version": "0.3.1"
 }

--- a/context.js
+++ b/context.js
@@ -273,7 +273,7 @@ context = (function() {
 
 		clearMenuData(uniqueId($target));
 
-		$(document).off('contextmenu', selector).off('click', '.context-event');
+		$target.off('contextmenu').off('click', '.context-event');
 	}
 
 	function destroyContextDelegate(el, selector) {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "context.js",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "",
   "main": "index.js",
   "license": "Unlicense",


### PR DESCRIPTION
I'm not 100% why this works so much better, but the former never destroyed the context menu. This works on both IE and Chrome. Also makes more sense that destroyContext should act directly on the target and destroyContextDelegate should be in delegate form.